### PR TITLE
一些交互方面的功能更新和问题修复

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,6 @@ jobs:
       - name: Install and build frontend
         run: |
           npm --prefix frontend ci
-          npm --prefix frontend run format:check
           npm --prefix frontend run build
 
       - name: Archive frontend dist

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -936,6 +936,20 @@ function AppInner() {
                     void dispatch(addTrackRemote({ parentTrackId: parentId }));
                     break;
                 }
+                case "track.selectUp":
+                    window.dispatchEvent(
+                        new CustomEvent("hifi:selectAdjacentTrack", {
+                            detail: { direction: -1 },
+                        }),
+                    );
+                    break;
+                case "track.selectDown":
+                    window.dispatchEvent(
+                        new CustomEvent("hifi:selectAdjacentTrack", {
+                            detail: { direction: 1 },
+                        }),
+                    );
+                    break;
                 case "pianoRoll.shiftParamUp":
                 case "pianoRoll.shiftParamDown": {
                     const isUp = actionId === "pianoRoll.shiftParamUp";

--- a/frontend/src/components/layout/PianoRollPanel.tsx
+++ b/frontend/src/components/layout/PianoRollPanel.tsx
@@ -2479,11 +2479,19 @@ export const PianoRollPanel: React.FC = () => {
             const detail = (e as CustomEvent).detail;
             if (!detail?.op) return;
             const { op, ...data } = detail;
+            const active = document.activeElement as HTMLElement | null;
+            const inPianoRoll =
+                active?.hasAttribute("data-piano-roll-scroller") ||
+                active?.closest?.("[data-piano-roll-scroller]") ||
+                document.body.getAttribute("data-hs-focus-window") === "pianoRoll";
+            const inTrackHeader =
+                Boolean(active?.closest?.("[data-track-list-panel]")) ||
+                document.body.getAttribute("data-hs-focus-window") === "trackHeader";
+
+            if (op === "paste" && !inPianoRoll && !inTrackHeader) {
+                return;
+            }
             if (op === "selectAll" || op === "deselect") {
-                const active = document.activeElement as HTMLElement | null;
-                const inPianoRoll =
-                    active?.hasAttribute("data-piano-roll-scroller") ||
-                    active?.closest?.("[data-piano-roll-scroller]");
                 if (!inPianoRoll || s.toolMode !== "select") {
                     return;
                 }

--- a/frontend/src/components/layout/TimelinePanel.tsx
+++ b/frontend/src/components/layout/TimelinePanel.tsx
@@ -19,7 +19,6 @@ import {
     selectTrackRemote,
     setTrackStateRemote,
     seekPlayhead,
-    selectClipRemote,
     moveTrackRemote,
     setClipMuted,
     importAudioAtPosition,
@@ -166,6 +165,7 @@ export const TimelinePanel: React.FC = () => {
         splitClipIdsAtPlayhead,
         splitSelectedAtPlayhead,
         selectClipRangeByRect,
+        rangeSelectAnchorClipId,
         pasteClipsAtPlayhead,
         clearContextMenu,
         ensureTrackLaneSelected,
@@ -173,6 +173,7 @@ export const TimelinePanel: React.FC = () => {
         openTrackLaneContextMenu,
         seekFromTrackLaneClientX,
         toggleTrackLaneClipMuted,
+        toggleTrackLaneCtrlSelection,
         toggleTrackLaneMultiSelect,
         commitTrackLaneRename,
         handleTrackLaneRenameDone,
@@ -205,11 +206,13 @@ export const TimelinePanel: React.FC = () => {
         dispatch,
         sessionRef,
         scrollRef,
+        trackListScrollRef,
         pxPerSecRef,
         viewportWidthRef,
         keyboardZoomPendingRef,
         pxPerSec,
         setPxPerSec,
+        rowHeight,
         multiSelectedClipIds,
         setMultiSelectedClipIds,
         clipClipboardRef,
@@ -303,15 +306,7 @@ export const TimelinePanel: React.FC = () => {
         gridSnapEnabled: s.gridSnapEnabled,
         copyDragKb,
         autoCrossfadeEnabled: s.autoCrossfadeEnabled,
-        onCtrlClick: (clipId: string) => {
-            setMultiSelectedClipIds((prev) => {
-                if (prev.includes(clipId)) {
-                    return prev.filter((id) => id !== clipId);
-                }
-                return [...prev, clipId];
-            });
-            void dispatch(selectClipRemote(clipId));
-        },
+        onCtrlClick: toggleTrackLaneCtrlSelection,
     });
 
     const newTrackGhostClips = useMemo(() => {
@@ -367,7 +362,10 @@ export const TimelinePanel: React.FC = () => {
                 trackVolumeUi={trackVolumeUi}
                 listScrollRef={trackListScrollRef}
                 onSelectTrack={(trackId) => {
-                    dispatch(selectTrackRemote(trackId));
+                    if (sessionRef.current.selectedTrackId === trackId) {
+                        return;
+                    }
+                    void dispatch(selectTrackRemote(trackId));
                 }}
                 onRemoveTrack={(trackId) => {
                     dispatch(removeTrackRemote(trackId));
@@ -852,6 +850,7 @@ export const TimelinePanel: React.FC = () => {
                                     ensureSelected={ensureTrackLaneSelected}
                                     selectClipRemote={selectTrackLaneClipRemote}
                                     onShiftRangeSelect={selectClipRangeByRect}
+                                    rangeSelectAnchorClipId={rangeSelectAnchorClipId}
                                     openContextMenu={openTrackLaneContextMenu}
                                     seekFromClientX={seekFromTrackLaneClientX}
                                     ghostDrag={ghostDrag}
@@ -859,6 +858,7 @@ export const TimelinePanel: React.FC = () => {
                                     startClipDrag={startClipDrag}
                                     startEditDrag={startEditDrag}
                                     toggleClipMuted={toggleTrackLaneClipMuted}
+                                    onCtrlToggleSelect={toggleTrackLaneCtrlSelection}
                                     clearContextMenu={clearContextMenu}
                                     toggleMultiSelect={toggleTrackLaneMultiSelect}
                                     renamingClipId={renamingClipId}

--- a/frontend/src/components/layout/pianoRoll/usePianoRollInteractions.ts
+++ b/frontend/src/components/layout/pianoRoll/usePianoRollInteractions.ts
@@ -1037,6 +1037,16 @@ export function usePianoRollInteractions(args: {
 
     const onScrollerKeyDown = useCallback(
         (e: KeyboardEvent<HTMLDivElement>) => {
+            const key = e.key.toLowerCase();
+            if (
+                key === "arrowup" ||
+                key === "arrowdown" ||
+                key === "arrowleft" ||
+                key === "arrowright"
+            ) {
+                e.preventDefault();
+            }
+
             if (!rootTrackId) return;
             if (editParam === "pitch" && !pitchEnabled) return;
 

--- a/frontend/src/components/layout/timeline/ClipItem.tsx
+++ b/frontend/src/components/layout/timeline/ClipItem.tsx
@@ -35,8 +35,10 @@ export const ClipItem = React.memo(function ClipItem({
     startClipDrag,
     startEditDrag,
     toggleClipMuted,
+    onCtrlToggleSelect,
     toggleMultiSelect: _toggleMultiSelect,
     onShiftRangeSelect,
+    rangeSelectAnchorClipId,
     clearContextMenu,
     triggerRename,
     onRenameCommit,
@@ -82,10 +84,14 @@ export const ClipItem = React.memo(function ClipItem({
             | "gain",
     ) => void;
     toggleClipMuted: (clipId: string, nextMuted: boolean) => void;
+    /** Ctrl+左键选择切换（会更新主选中 clip） */
+    onCtrlToggleSelect: (clipId: string) => void;
     /** Ctrl+左键多选切换 */
     toggleMultiSelect: (clipId: string) => void;
     /** Shift+点击范围选择（跨轨按包围矩形选中） */
-    onShiftRangeSelect: (clipId: string) => void;
+    onShiftRangeSelect: (clipId: string, anchorClipIdOverride?: string | null) => void;
+    /** Shift 范围选择锚点（点击前快照） */
+    rangeSelectAnchorClipId: string | null;
 
     clearContextMenu: () => void;
 
@@ -111,10 +117,19 @@ export const ClipItem = React.memo(function ClipItem({
             e.stopPropagation();
             clearContextMenu();
 
-            if (multiSelectedCount === 0 || !isInMultiSelectedSet) {
-                ensureSelected(clip.id);
+            const alt = Boolean(altPressed || e.altKey || e.nativeEvent.getModifierState?.("Alt"));
+            const ctrlOrMeta = e.ctrlKey || e.metaKey;
+            const doShiftRangeSelect = e.shiftKey && !alt && !ctrlOrMeta;
+            const shiftRangeAnchorClipId = doShiftRangeSelect ? rangeSelectAnchorClipId : null;
+            const doCtrlToggleOnly = ctrlOrMeta && !e.shiftKey && !alt;
+            const shouldPrimeSelection = !doCtrlToggleOnly && !doShiftRangeSelect;
+
+            if (shouldPrimeSelection) {
+                if (multiSelectedCount === 0 || !isInMultiSelectedSet) {
+                    ensureSelected(clip.id);
+                }
+                selectClipRemote(clip.id);
             }
-            selectClipRemote(clip.id);
 
             const startX = e.clientX;
             const startY = e.clientY;
@@ -145,6 +160,14 @@ export const ClipItem = React.memo(function ClipItem({
                 window.removeEventListener("pointerup", onEnd, true);
                 window.removeEventListener("pointercancel", onEnd, true);
                 if (!dragStarted) {
+                    if (doCtrlToggleOnly) {
+                        onCtrlToggleSelect(clip.id);
+                        return;
+                    }
+                    if (doShiftRangeSelect) {
+                        onShiftRangeSelect(clip.id, shiftRangeAnchorClipId);
+                        return;
+                    }
                     seekFromClientX(ev.clientX, true);
                 }
             };
@@ -159,9 +182,13 @@ export const ClipItem = React.memo(function ClipItem({
             ensureSelected,
             isInMultiSelectedSet,
             multiSelectedCount,
+            onCtrlToggleSelect,
+            onShiftRangeSelect,
+            rangeSelectAnchorClipId,
             seekFromClientX,
             selectClipRemote,
             startEditDrag,
+            altPressed,
         ],
     );
 
@@ -209,13 +236,16 @@ export const ClipItem = React.memo(function ClipItem({
                 const alt = Boolean(
                     altPressed || e.altKey || e.nativeEvent.getModifierState?.("Alt"),
                 );
+                const ctrlOrMeta = e.ctrlKey || e.metaKey;
 
                 // Shift+点击范围选择在 pointerup 时处理（避免阻止拖动）
-                const doShiftRangeSelect = e.shiftKey && !alt && !e.ctrlKey && !e.metaKey;
+                const doShiftRangeSelect = e.shiftKey && !alt && !ctrlOrMeta;
+                const shiftRangeAnchorClipId = doShiftRangeSelect ? rangeSelectAnchorClipId : null;
+                const doCtrlToggleOnly = ctrlOrMeta && !e.shiftKey && !alt;
 
                 // Seek should happen on click, not on drag.
                 // Track whether the pointer moved beyond a small deadzone.
-                const allowSeek = !alt && !e.ctrlKey && !e.metaKey;
+                const allowSeek = !alt && !ctrlOrMeta && !e.shiftKey;
                 const startX = e.clientX;
                 const startY = e.clientY;
                 let moved = false;
@@ -234,7 +264,7 @@ export const ClipItem = React.memo(function ClipItem({
                     window.removeEventListener("pointercancel", onUp, true);
                     // Shift+点击且未移动时执行范围选择
                     if (doShiftRangeSelect && !moved) {
-                        onShiftRangeSelect(clip.id);
+                        onShiftRangeSelect(clip.id, shiftRangeAnchorClipId);
                     } else if (!moved && allowSeek) {
                         seekFromClientX(ev.clientX, true);
                     }
@@ -248,10 +278,13 @@ export const ClipItem = React.memo(function ClipItem({
                 e.stopPropagation();
                 clearContextMenu();
 
-                if (multiSelectedCount === 0 || !isInMultiSelectedSet) {
-                    ensureSelected(clip.id);
+                const shouldPrimeSelection = !doCtrlToggleOnly && !doShiftRangeSelect;
+                if (shouldPrimeSelection) {
+                    if (multiSelectedCount === 0 || !isInMultiSelectedSet) {
+                        ensureSelected(clip.id);
+                    }
+                    selectClipRemote(clip.id);
                 }
-                selectClipRemote(clip.id);
                 startClipDrag(e, clip.id, clip.startSec, alt);
             }}
             title={clip.sourcePath ?? clip.name}
@@ -263,6 +296,9 @@ export const ClipItem = React.memo(function ClipItem({
                 isInMultiSelectedSet={isInMultiSelectedSet}
                 ensureSelected={ensureSelected}
                 selectClipRemote={selectClipRemote}
+                onCtrlToggleSelect={onCtrlToggleSelect}
+                onShiftRangeSelect={onShiftRangeSelect}
+                rangeSelectAnchorClipId={rangeSelectAnchorClipId}
                 seekFromClientX={seekFromClientX}
                 startEditDrag={startEditDrag}
             />

--- a/frontend/src/components/layout/timeline/TrackLane.tsx
+++ b/frontend/src/components/layout/timeline/TrackLane.tsx
@@ -56,10 +56,14 @@ export const TrackLane = React.memo(function TrackLane(props: {
             | "gain",
     ) => void;
     toggleClipMuted: (clipId: string, nextMuted: boolean) => void;
+    /** Ctrl+左键选择切换（会更新主选中 clip） */
+    onCtrlToggleSelect: (clipId: string) => void;
     /** Ctrl+左键多选切换 */
     toggleMultiSelect: (clipId: string) => void;
     /** Shift+点击范围选择 */
-    onShiftRangeSelect: (clipId: string) => void;
+    onShiftRangeSelect: (clipId: string, anchorClipIdOverride?: string | null) => void;
+    /** Shift 范围选择锚点（点击前快照） */
+    rangeSelectAnchorClipId: string | null;
 
     clearContextMenu: () => void;
 
@@ -95,8 +99,10 @@ export const TrackLane = React.memo(function TrackLane(props: {
         startClipDrag,
         startEditDrag,
         toggleClipMuted,
+        onCtrlToggleSelect,
         toggleMultiSelect,
         onShiftRangeSelect,
+        rangeSelectAnchorClipId,
         clearContextMenu,
         renamingClipId,
         onRenameCommit,
@@ -218,8 +224,10 @@ export const TrackLane = React.memo(function TrackLane(props: {
                         startClipDrag={startClipDrag}
                         startEditDrag={startEditDrag}
                         toggleClipMuted={toggleClipMuted}
+                        onCtrlToggleSelect={onCtrlToggleSelect}
                         toggleMultiSelect={toggleMultiSelect}
                         onShiftRangeSelect={onShiftRangeSelect}
+                        rangeSelectAnchorClipId={rangeSelectAnchorClipId}
                         clearContextMenu={clearContextMenu}
                         triggerRename={renamingClipId === clip.id}
                         onRenameCommit={onRenameCommit}

--- a/frontend/src/components/layout/timeline/TrackList.tsx
+++ b/frontend/src/components/layout/timeline/TrackList.tsx
@@ -447,6 +447,12 @@ export const TrackList: React.FC<{
         return false;
     }
 
+    function isArrowNavigationKey(key: string): boolean {
+        return (
+            key === "arrowup" || key === "arrowdown" || key === "arrowleft" || key === "arrowright"
+        );
+    }
+
     function startPanPointerLocal(e: React.PointerEvent) {
         // Intercept middle-button mouse to prevent browser native autoscroll
         if (e.pointerType === "mouse" && e.button === 1) {
@@ -781,7 +787,24 @@ export const TrackList: React.FC<{
                     (listRef as React.MutableRefObject<HTMLDivElement | null>).current = el;
                     if (listScrollRef) listScrollRef.current = el;
                 }}
-                onPointerDown={(e) => startPanPointerLocal?.(e)}
+                data-track-list-panel
+                onFocusCapture={() => {
+                    document.body.setAttribute("data-hs-focus-window", "trackHeader");
+                }}
+                onMouseDownCapture={() => {
+                    document.body.setAttribute("data-hs-focus-window", "trackHeader");
+                }}
+                onPointerDown={(e) => {
+                    document.body.setAttribute("data-hs-focus-window", "trackHeader");
+                    startPanPointerLocal?.(e);
+                }}
+                onKeyDownCapture={(e) => {
+                    if (isEditableTarget(e.target)) return;
+                    const key = e.key.toLowerCase();
+                    if (isArrowNavigationKey(key)) {
+                        e.preventDefault();
+                    }
+                }}
                 onAuxClick={(e) => {
                     // Prevent native autoscroll overlay on middle click
                     e.preventDefault();
@@ -834,6 +857,11 @@ export const TrackList: React.FC<{
                             key={track.id}
                             style={{ height: rowHeight }}
                             className="border-b border-qt-border relative group overflow-hidden"
+                            onPointerDownCapture={(e) => {
+                                if (e.button !== 0) return;
+                                if (selectedTrackId === track.id) return;
+                                onSelectTrack(track.id);
+                            }}
                             onContextMenu={(e) => {
                                 e.preventDefault();
                                 setTrackCtxMenu({
@@ -953,7 +981,6 @@ export const TrackList: React.FC<{
                                     setDragUi(null);
 
                                     if (!moved) {
-                                        onSelectTrack(drag.trackId);
                                         return;
                                     }
 

--- a/frontend/src/components/layout/timeline/clip/ClipEdgeHandles.tsx
+++ b/frontend/src/components/layout/timeline/clip/ClipEdgeHandles.tsx
@@ -7,6 +7,9 @@ export const ClipEdgeHandles: React.FC<{
     isInMultiSelectedSet: boolean;
     ensureSelected: (clipId: string) => void;
     selectClipRemote: (clipId: string) => void;
+    onCtrlToggleSelect: (clipId: string) => void;
+    onShiftRangeSelect: (clipId: string, anchorClipIdOverride?: string | null) => void;
+    rangeSelectAnchorClipId: string | null;
     seekFromClientX: (clientX: number, commit: boolean) => void;
     startEditDrag: (
         e: React.PointerEvent,
@@ -20,6 +23,9 @@ export const ClipEdgeHandles: React.FC<{
     isInMultiSelectedSet,
     ensureSelected,
     selectClipRemote,
+    onCtrlToggleSelect,
+    onShiftRangeSelect,
+    rangeSelectAnchorClipId,
     seekFromClientX,
     startEditDrag,
 }) => {
@@ -41,16 +47,30 @@ export const ClipEdgeHandles: React.FC<{
                     if (e.button !== 0) return;
                     e.preventDefault();
                     e.stopPropagation();
-                    if (multiSelectedCount === 0 || !isInMultiSelectedSet) {
-                        ensureSelected(clipId);
+
+                    const alt = Boolean(
+                        altPressed || e.altKey || e.nativeEvent.getModifierState?.("Alt"),
+                    );
+                    const ctrlOrMeta = e.ctrlKey || e.metaKey;
+                    const doShiftRangeSelect = e.shiftKey && !alt && !ctrlOrMeta;
+                    const shiftRangeAnchorClipId = doShiftRangeSelect
+                        ? rangeSelectAnchorClipId
+                        : null;
+                    const doCtrlToggleOnly = ctrlOrMeta && !e.shiftKey && !alt;
+                    const shouldPrimeSelection = !doCtrlToggleOnly && !doShiftRangeSelect;
+
+                    if (shouldPrimeSelection) {
+                        if (multiSelectedCount === 0 || !isInMultiSelectedSet) {
+                            ensureSelected(clipId);
+                        }
+                        selectClipRemote(clipId);
                     }
-                    selectClipRemote(clipId);
 
                     const startX = e.clientX;
                     const startY = e.clientY;
                     const pointerId = e.pointerId;
                     const targetEl = e.currentTarget as HTMLElement;
-                    const mode = altPressed ? "stretch_left" : "trim_left";
+                    const mode = alt ? "stretch_left" : "trim_left";
                     let dragStarted = false;
 
                     const onMove = (ev: PointerEvent) => {
@@ -76,6 +96,14 @@ export const ClipEdgeHandles: React.FC<{
                         window.removeEventListener("pointerup", onEnd, true);
                         window.removeEventListener("pointercancel", onEnd, true);
                         if (!dragStarted) {
+                            if (doCtrlToggleOnly) {
+                                onCtrlToggleSelect(clipId);
+                                return;
+                            }
+                            if (doShiftRangeSelect) {
+                                onShiftRangeSelect(clipId, shiftRangeAnchorClipId);
+                                return;
+                            }
                             seekFromClientX(ev.clientX, true);
                         }
                     };
@@ -95,16 +123,30 @@ export const ClipEdgeHandles: React.FC<{
                     if (e.button !== 0) return;
                     e.preventDefault();
                     e.stopPropagation();
-                    if (multiSelectedCount === 0 || !isInMultiSelectedSet) {
-                        ensureSelected(clipId);
+
+                    const alt = Boolean(
+                        altPressed || e.altKey || e.nativeEvent.getModifierState?.("Alt"),
+                    );
+                    const ctrlOrMeta = e.ctrlKey || e.metaKey;
+                    const doShiftRangeSelect = e.shiftKey && !alt && !ctrlOrMeta;
+                    const shiftRangeAnchorClipId = doShiftRangeSelect
+                        ? rangeSelectAnchorClipId
+                        : null;
+                    const doCtrlToggleOnly = ctrlOrMeta && !e.shiftKey && !alt;
+                    const shouldPrimeSelection = !doCtrlToggleOnly && !doShiftRangeSelect;
+
+                    if (shouldPrimeSelection) {
+                        if (multiSelectedCount === 0 || !isInMultiSelectedSet) {
+                            ensureSelected(clipId);
+                        }
+                        selectClipRemote(clipId);
                     }
-                    selectClipRemote(clipId);
 
                     const startX = e.clientX;
                     const startY = e.clientY;
                     const pointerId = e.pointerId;
                     const targetEl = e.currentTarget as HTMLElement;
-                    const mode = altPressed ? "stretch_right" : "trim_right";
+                    const mode = alt ? "stretch_right" : "trim_right";
                     let dragStarted = false;
 
                     const onMove = (ev: PointerEvent) => {
@@ -130,6 +172,14 @@ export const ClipEdgeHandles: React.FC<{
                         window.removeEventListener("pointerup", onEnd, true);
                         window.removeEventListener("pointercancel", onEnd, true);
                         if (!dragStarted) {
+                            if (doCtrlToggleOnly) {
+                                onCtrlToggleSelect(clipId);
+                                return;
+                            }
+                            if (doShiftRangeSelect) {
+                                onShiftRangeSelect(clipId, shiftRangeAnchorClipId);
+                                return;
+                            }
                             seekFromClientX(ev.clientX, true);
                         }
                     };

--- a/frontend/src/components/layout/timeline/hooks/useClipDrag.ts
+++ b/frontend/src/components/layout/timeline/hooks/useClipDrag.ts
@@ -63,6 +63,7 @@ export type ClipDragState = {
     lastTrackId: string | null;
     lastDeltaBeat: number;
     copyMode: boolean;
+    ctrlSelectionToggle: boolean;
     startClientX: number;
     startClientY: number;
     hasMoved: boolean;
@@ -232,6 +233,7 @@ export function useClipDrag(deps: {
             lastTrackId: targetTrackId,
             lastDeltaBeat: 0,
             copyMode: isModifierActive(copyDragKb, e.nativeEvent),
+            ctrlSelectionToggle: e.ctrlKey || e.metaKey,
             startClientX: e.clientX,
             startClientY: e.clientY,
             hasMoved: false,
@@ -368,7 +370,7 @@ export function useClipDrag(deps: {
 
             if (!drag.hasMoved) {
                 // Ctrl+点击（未移动）：执行多选切换
-                if (drag.copyMode && onCtrlClick) {
+                if (drag.ctrlSelectionToggle && onCtrlClick) {
                     onCtrlClick(drag.anchorClipId);
                 }
                 window.removeEventListener("pointermove", onMove);

--- a/frontend/src/components/layout/timeline/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/components/layout/timeline/hooks/useKeyboardShortcuts.ts
@@ -100,12 +100,24 @@ export function useKeyboardShortcuts(deps: {
                       ? [s.selectedClipId]
                       : [];
 
+            const active = document.activeElement as HTMLElement | null;
+            const inPianoRoll =
+                active?.hasAttribute("data-piano-roll-scroller") ||
+                active?.closest?.("[data-piano-roll-scroller]");
+            const inTrackHeader =
+                Boolean(active?.closest?.("[data-track-list-panel]")) ||
+                document.body.getAttribute("data-hs-focus-window") === "trackHeader";
+
+            // clip.paste 与 pianoRoll.paste 冲突时：参数编辑器 / 轨道头焦点优先参数粘贴
+            if (actionId === "clip.paste" && (inPianoRoll || inTrackHeader)) {
+                e.preventDefault();
+                e.stopPropagation();
+                window.dispatchEvent(new CustomEvent("hifi:editOp", { detail: { op: "paste" } }));
+                return;
+            }
+
             // clip.copy / clip.cut / clip.paste: 焦点在 PianoRoll 时优先交给参数编辑器。
             if (actionId === "clip.copy" || actionId === "clip.cut" || actionId === "clip.paste") {
-                const active = document.activeElement as HTMLElement | null;
-                const inPianoRoll =
-                    active?.hasAttribute("data-piano-roll-scroller") ||
-                    active?.closest?.("[data-piano-roll-scroller]");
                 if (inPianoRoll) {
                     if (s.toolMode === "select") {
                         e.preventDefault();

--- a/frontend/src/components/layout/timeline/hooks/useTimelineClipActions.ts
+++ b/frontend/src/components/layout/timeline/hooks/useTimelineClipActions.ts
@@ -25,6 +25,7 @@ import {
     setMultiSelectedClipIds as setMultiSelectedClipIdsAction,
     setplayheadSec,
     setSelectedClip,
+    setSelectedClipPreservingTrack,
     replaceClipSourceRemote,
     splitClipRemote,
 } from "../../../../features/session/sessionSlice";
@@ -118,7 +119,8 @@ export interface UseTimelineClipActionsResult {
     replaceClipSources: (ids: string[]) => Promise<void>;
     splitClipIdsAtPlayhead: (clipIds: string[]) => string[];
     splitSelectedAtPlayhead: () => void;
-    selectClipRangeByRect: (targetClipId: string) => void;
+    selectClipRangeByRect: (targetClipId: string, anchorClipIdOverride?: string | null) => void;
+    rangeSelectAnchorClipId: string | null;
     pasteClipsAtPlayhead: () => void;
     clearContextMenu: () => void;
 
@@ -128,6 +130,7 @@ export interface UseTimelineClipActionsResult {
     openTrackLaneContextMenu: (clipId: string, clientX: number, clientY: number) => void;
     seekFromTrackLaneClientX: (clientX: number, commit: boolean) => void;
     toggleTrackLaneClipMuted: (clipId: string, nextMuted: boolean) => void;
+    toggleTrackLaneCtrlSelection: (clipId: string) => void;
     toggleTrackLaneMultiSelect: (clipId: string) => void;
     commitTrackLaneRename: (clipId: string, newName: string) => void;
     handleTrackLaneRenameDone: () => void;
@@ -373,12 +376,16 @@ export function useTimelineClipActions(
 
     // ── selectClipRangeByRect ────────────────────────────────
     const selectClipRangeByRect = React.useCallback(
-        (targetClipId: string) => {
+        (targetClipId: string, anchorClipIdOverride?: string | null) => {
             const session = sessionRef.current;
             const target = session.clips.find((c) => c.id === targetClipId);
             if (!target) return;
 
-            const anchorId = lastClickedClipIdRef.current ?? session.selectedClipId ?? targetClipId;
+            const anchorId =
+                anchorClipIdOverride ??
+                lastClickedClipIdRef.current ??
+                session.selectedClipId ??
+                targetClipId;
             const anchor = session.clips.find((c) => c.id === anchorId) ?? target;
 
             const trackIndexById = new Map(session.tracks.map((track, index) => [track.id, index]));
@@ -407,7 +414,7 @@ export function useTimelineClipActions(
                     }
                     const clipStart = clip.startSec;
                     const clipEnd = clip.startSec + clip.lengthSec;
-                    return clipStart >= minStartSec && clipEnd <= maxEndSec;
+                    return clipEnd >= minStartSec && clipStart <= maxEndSec;
                 })
                 .map((clip) => clip.id);
 
@@ -515,10 +522,78 @@ export function useTimelineClipActions(
     const selectTrackLaneClipRemote = React.useCallback(
         (clipId: string) => {
             lastClickedClipIdRef.current = clipId;
-            void dispatch(selectClipRemote(clipId));
+            const clip = sessionRef.current.clips.find((entry) => entry.id === clipId);
+            const clipTrackId = clip?.trackId ?? null;
+            if (
+                sessionRef.current.selectedClipId === clipId &&
+                clipTrackId != null &&
+                clipTrackId === sessionRef.current.selectedTrackId
+            ) {
+                return;
+            }
+            const preserveTrackFocus = Boolean(
+                clip && clip.trackId === sessionRef.current.selectedTrackId,
+            );
+            void dispatch(
+                selectClipRemote({
+                    clipId,
+                    preserveTrackFocus,
+                }),
+            );
         },
         [dispatch],
     );
+
+    const toggleTrackLaneCtrlSelection = React.useCallback(
+        (clipId: string) => {
+            lastClickedClipIdRef.current = clipId;
+
+            const currentSelectionIds =
+                multiSelectedClipIdsRef.current.length > 0
+                    ? [...multiSelectedClipIdsRef.current]
+                    : sessionRef.current.selectedClipId
+                      ? [sessionRef.current.selectedClipId]
+                      : [];
+
+            const alreadySelected = currentSelectionIds.includes(clipId);
+            const nextSelectionIds = alreadySelected
+                ? currentSelectionIds.filter((id) => id !== clipId)
+                : [...currentSelectionIds, clipId];
+
+            setMultiSelectedClipIds(nextSelectionIds);
+
+            if (nextSelectionIds.length === 0) {
+                dispatch(setSelectedClipPreservingTrack(null));
+                return;
+            }
+
+            const nextPrimaryClipId = alreadySelected
+                ? (nextSelectionIds[nextSelectionIds.length - 1] ?? null)
+                : clipId;
+            if (!nextPrimaryClipId) {
+                dispatch(setSelectedClipPreservingTrack(null));
+                return;
+            }
+
+            const nextPrimaryClip = sessionRef.current.clips.find(
+                (entry) => entry.id === nextPrimaryClipId,
+            );
+            const preserveTrackFocus = Boolean(
+                nextPrimaryClip && nextPrimaryClip.trackId === sessionRef.current.selectedTrackId,
+            );
+
+            void dispatch(
+                selectClipRemote({
+                    clipId: nextPrimaryClipId,
+                    preserveTrackFocus,
+                }),
+            );
+        },
+        [dispatch, setMultiSelectedClipIds],
+    );
+
+    const rangeSelectAnchorClipId =
+        lastClickedClipIdRef.current ?? sessionRef.current.selectedClipId ?? null;
 
     const openTrackLaneContextMenu = React.useCallback(
         (clipId: string, clientX: number, clientY: number) => {
@@ -629,6 +704,7 @@ export function useTimelineClipActions(
         splitClipIdsAtPlayhead,
         splitSelectedAtPlayhead,
         selectClipRangeByRect,
+        rangeSelectAnchorClipId,
         pasteClipsAtPlayhead,
         clearContextMenu,
 
@@ -637,6 +713,7 @@ export function useTimelineClipActions(
         openTrackLaneContextMenu,
         seekFromTrackLaneClientX,
         toggleTrackLaneClipMuted,
+        toggleTrackLaneCtrlSelection,
         toggleTrackLaneMultiSelect,
         commitTrackLaneRename,
         handleTrackLaneRenameDone,

--- a/frontend/src/components/layout/timeline/hooks/useTimelineEventHandlers.ts
+++ b/frontend/src/components/layout/timeline/hooks/useTimelineEventHandlers.ts
@@ -14,6 +14,7 @@ import { useEffect } from "react";
 import type { AppDispatch, RootState } from "../../../../app/store";
 import {
     seekPlayhead,
+    selectTrackRemote,
     setplayheadSec,
     setSelectedClip,
     setSelectedClipPreservingTrack,
@@ -29,6 +30,7 @@ export interface UseTimelineEventHandlersArgs {
     dispatch: AppDispatch;
     sessionRef: React.MutableRefObject<RootState["session"]>;
     scrollRef: React.MutableRefObject<HTMLDivElement | null>;
+    trackListScrollRef: React.MutableRefObject<HTMLDivElement | null>;
     pxPerSecRef: React.MutableRefObject<number>;
     viewportWidthRef: React.MutableRefObject<number>;
     keyboardZoomPendingRef: React.MutableRefObject<{
@@ -39,6 +41,7 @@ export interface UseTimelineEventHandlersArgs {
     // state values
     pxPerSec: number;
     setPxPerSec: React.Dispatch<React.SetStateAction<number>>;
+    rowHeight: number;
 
     // multi-select
     multiSelectedClipIds: string[];
@@ -97,10 +100,12 @@ export function useTimelineEventHandlers(args: UseTimelineEventHandlersArgs): vo
         dispatch,
         sessionRef,
         scrollRef,
+        trackListScrollRef,
         pxPerSecRef,
         keyboardZoomPendingRef,
         pxPerSec,
         setPxPerSec,
+        rowHeight,
         multiSelectedClipIds,
         setMultiSelectedClipIds,
         clipClipboardRef,
@@ -141,11 +146,17 @@ export function useTimelineEventHandlers(args: UseTimelineEventHandlersArgs): vo
             const inPianoRoll =
                 active?.hasAttribute("data-piano-roll-scroller") ||
                 active?.closest?.("[data-piano-roll-scroller]");
+            const inTrackHeader =
+                Boolean(active?.closest?.("[data-track-list-panel]")) ||
+                document.body.getAttribute("data-hs-focus-window") === "trackHeader";
             const deferToPianoRollForSelection =
                 inPianoRoll &&
                 sessionRef.current.toolMode === "select" &&
                 (op === "selectAll" || op === "deselect");
             if (deferToPianoRollForSelection) return;
+            if (op === "paste" && (inPianoRoll || inTrackHeader)) {
+                return;
+            }
             if (inPianoRoll && op !== "selectAll" && op !== "deselect") {
                 return;
             }
@@ -173,6 +184,82 @@ export function useTimelineEventHandlers(args: UseTimelineEventHandlersArgs): vo
         window.addEventListener("hifi:editOp", onEditOp as EventListener);
         return () => window.removeEventListener("hifi:editOp", onEditOp as EventListener);
     }, [pasteClipsAtPlayhead, splitSelectedAtPlayhead]);
+
+    // ── hifi:selectAdjacentTrack ────────────────────────────
+    useEffect(() => {
+        function onSelectAdjacentTrack(e: Event) {
+            const direction = Math.sign(
+                Number((e as CustomEvent<{ direction?: number }>).detail?.direction ?? 0),
+            );
+            if (!direction) return;
+
+            const tracks = sessionRef.current.tracks;
+            if (tracks.length === 0) return;
+
+            const currentTrackId = sessionRef.current.selectedTrackId ?? tracks[0]?.id ?? null;
+            if (!currentTrackId) return;
+
+            let currentIndex = tracks.findIndex((track) => track.id === currentTrackId);
+            if (currentIndex < 0) currentIndex = 0;
+
+            const nextIndex = Math.max(0, Math.min(tracks.length - 1, currentIndex + direction));
+            if (nextIndex === currentIndex) return;
+
+            const nextTrackId = tracks[nextIndex]?.id;
+            if (!nextTrackId) return;
+
+            void dispatch(selectTrackRemote(nextTrackId));
+
+            const ensureTrackVisible = (el: HTMLDivElement): number | null => {
+                const trackTop = nextIndex * rowHeight;
+                const trackBottom = trackTop + rowHeight;
+                let nextScrollTop = el.scrollTop;
+
+                if (trackTop < el.scrollTop) {
+                    nextScrollTop = trackTop;
+                } else if (trackBottom > el.scrollTop + el.clientHeight) {
+                    nextScrollTop = trackBottom - el.clientHeight;
+                }
+
+                const maxScrollTop = Math.max(0, el.scrollHeight - el.clientHeight);
+                nextScrollTop = Math.max(0, Math.min(maxScrollTop, nextScrollTop));
+                if (Math.abs(nextScrollTop - el.scrollTop) <= 0.5) return null;
+                el.scrollTop = nextScrollTop;
+                return nextScrollTop;
+            };
+
+            const timelineScroller = scrollRef.current;
+            const trackScroller = trackListScrollRef.current;
+
+            const timelineNextScrollTop = timelineScroller
+                ? ensureTrackVisible(timelineScroller)
+                : null;
+
+            if (!trackScroller) return;
+            if (timelineNextScrollTop != null) {
+                if (Math.abs(trackScroller.scrollTop - timelineNextScrollTop) > 0.5) {
+                    trackScroller.scrollTop = timelineNextScrollTop;
+                }
+                return;
+            }
+
+            const trackNextScrollTop = ensureTrackVisible(trackScroller);
+            if (
+                trackNextScrollTop != null &&
+                timelineScroller &&
+                Math.abs(timelineScroller.scrollTop - trackNextScrollTop) > 0.5
+            ) {
+                timelineScroller.scrollTop = trackNextScrollTop;
+            }
+        }
+
+        window.addEventListener("hifi:selectAdjacentTrack", onSelectAdjacentTrack as EventListener);
+        return () =>
+            window.removeEventListener(
+                "hifi:selectAdjacentTrack",
+                onSelectAdjacentTrack as EventListener,
+            );
+    }, [dispatch, rowHeight]);
 
     // ── hifi:nudgePlayhead ───────────────────────────────────
     useEffect(() => {

--- a/frontend/src/features/keybindings/defaultKeybindings.ts
+++ b/frontend/src/features/keybindings/defaultKeybindings.ts
@@ -18,8 +18,8 @@ export const DEFAULT_KEYBINDINGS: KeybindingMap = {
     "playback.focusCursor": { key: "\\" }, // 聚焦播放光标
     "playback.seekLeft": { key: "arrowleft" },
     "playback.seekRight": { key: "arrowright" },
-    "timeline.zoomIn": { key: "arrowup" },
-    "timeline.zoomOut": { key: "arrowdown" },
+    "timeline.zoomIn": { key: "__none__" },
+    "timeline.zoomOut": { key: "__none__" },
 
     // 编辑
     "edit.undo": { key: "z", ctrl: true },
@@ -47,6 +47,8 @@ export const DEFAULT_KEYBINDINGS: KeybindingMap = {
 
     // 轨道
     "track.add": { key: "t", ctrl: true },
+    "track.selectUp": { key: "arrowup" },
+    "track.selectDown": { key: "arrowdown" },
 
     // Clip 操作
     "clip.delete": { key: "delete" },
@@ -197,6 +199,8 @@ export const ACTION_META: Record<ActionId, ActionMeta> = {
     "project.export": { labelKey: "kb_project_export", group: "project" },
 
     "track.add": { labelKey: "kb_track_add", group: "project" },
+    "track.selectUp": { labelKey: "kb_track_select_up", group: "project" },
+    "track.selectDown": { labelKey: "kb_track_select_down", group: "project" },
 
     "clip.delete": { labelKey: "kb_clip_delete", group: "clip" },
     "clip.copy": { labelKey: "kb_clip_copy", group: "clip" },

--- a/frontend/src/features/keybindings/types.ts
+++ b/frontend/src/features/keybindings/types.ts
@@ -36,6 +36,8 @@ export type ActionId =
     | "project.export" // 导出音频
     // 轨道
     | "track.add" // 新建轨道
+    | "track.selectUp" // 选择上一条轨道
+    | "track.selectDown" // 选择下一条轨道
     // Clip 操作
     | "clip.delete" // 删除选中 clip
     | "clip.copy" // 复制 clip

--- a/frontend/src/features/keybindings/useKeybindings.ts
+++ b/frontend/src/features/keybindings/useKeybindings.ts
@@ -8,6 +8,14 @@ const IS_MAC =
     typeof navigator !== "undefined" && navigator.platform?.toLowerCase().includes("mac");
 const EXCLUDE_QUICK_SEARCH = new Set(["quickSearch"]);
 const EXCLUDE_BOTH = new Set(["paramEditorSelect", "quickSearch"]);
+const REPEATABLE_ACTIONS = new Set<ActionId>([
+    "playback.seekLeft",
+    "playback.seekRight",
+    "timeline.zoomIn",
+    "timeline.zoomOut",
+    "track.selectUp",
+    "track.selectDown",
+]);
 /**
  * 判断当前焦点是否在可编辑元素上（输入框等），此时不拦截快捷键
  */
@@ -118,7 +126,6 @@ export function useKeybindings(handler: KeybindingActionHandler): void {
 
     useEffect(() => {
         function onKeyDown(e: KeyboardEvent) {
-            if (e.repeat) return;
             if (isEditableTarget(document.activeElement) || isEditableTarget(e.target)) return;
 
             // 快捷键设置对话框打开时，阻塞所有快捷键
@@ -127,11 +134,31 @@ export function useKeybindings(handler: KeybindingActionHandler): void {
             // Quick Search 打开时，交给弹窗自身输入框处理（避免 ↑/↓ 与时间轴缩放冲突）
             if (document.body.hasAttribute("data-quick-search-open")) return;
 
-            // PianoRoll scroller 内的快捷键由其自身 onKeyDown 处理，不拦截
             const active = document.activeElement as HTMLElement | null;
+            const focusWindow = document.body.getAttribute("data-hs-focus-window");
             const inPianoRoll =
                 active?.hasAttribute("data-piano-roll-scroller") ||
-                active?.closest?.("[data-piano-roll-scroller]");
+                active?.closest?.("[data-piano-roll-scroller]") ||
+                focusWindow === "pianoRoll";
+            const inTimeline =
+                active?.hasAttribute("data-timeline-scroller") ||
+                active?.closest?.("[data-timeline-scroller]") ||
+                focusWindow === "timeline";
+            const inTrackHeader =
+                Boolean(active?.closest?.("[data-track-list-panel]")) ||
+                focusWindow === "trackHeader";
+
+            const key = normalizeEventKey(e);
+            const isArrowKey =
+                key === "arrowup" ||
+                key === "arrowdown" ||
+                key === "arrowleft" ||
+                key === "arrowright";
+            if (isArrowKey && (inPianoRoll || inTimeline || inTrackHeader)) {
+                e.preventDefault();
+            }
+
+            // PianoRoll scroller 内的快捷键由其自身 onKeyDown 处理，不拦截
             if (inPianoRoll) {
                 // 查找匹配的 actionId，如果属于 pianoRoll.* 则放行给 PianoRoll 自己处理
                 const matchedAction = findMatchingAction(e, keybindingsRef.current);
@@ -161,6 +188,9 @@ export function useKeybindings(handler: KeybindingActionHandler): void {
                         EXCLUDE_BOTH,
                     );
                     if (fallbackAction) {
+                        if (e.repeat && !REPEATABLE_ACTIONS.has(fallbackAction)) {
+                            return;
+                        }
                         e.preventDefault();
                         e.stopPropagation();
                         handlerRef.current(fallbackAction);
@@ -181,6 +211,7 @@ export function useKeybindings(handler: KeybindingActionHandler): void {
                 inPianoRoll ? EXCLUDE_QUICK_SEARCH : EXCLUDE_BOTH,
             );
             if (!actionId) return;
+            if (e.repeat && !REPEATABLE_ACTIONS.has(actionId)) return;
 
             e.preventDefault();
             e.stopPropagation();

--- a/frontend/src/features/session/sessionSlice.ts
+++ b/frontend/src/features/session/sessionSlice.ts
@@ -1041,11 +1041,14 @@ const sessionSlice = createSlice({
             state.selectedClipId = action.payload;
             state.selectedPointId = null;
             if (action.payload) {
-                state.selectedTrackId = resolveTrackIdForClipSelection({
+                const nextTrackId = resolveTrackIdForClipSelection({
                     currentTrackId: state.selectedTrackId,
                     clips: state.clips,
                     clipId: action.payload,
                 });
+                if (nextTrackId !== state.selectedTrackId) {
+                    state.selectedTrackId = nextTrackId;
+                }
                 ensureClipAutomation(state, action.payload);
             }
         },
@@ -2403,13 +2406,18 @@ const sessionSlice = createSlice({
             .addCase(selectClipRemote.fulfilled, (state, action) => {
                 const payload = action.payload as {
                     ok?: boolean;
+                    __preserveTrackFocus?: boolean;
                 } & TimelineState;
                 if (!payload.ok) {
                     return;
                 }
                 const currentPlayheadSec = state.playheadSec;
+                const currentSelectedTrackId = state.selectedTrackId;
                 applyTimelineState(state, payload);
                 state.playheadSec = currentPlayheadSec;
+                if (payload.__preserveTrackFocus) {
+                    state.selectedTrackId = currentSelectedTrackId;
+                }
             })
 
             .addCase(setTrackStateRemote.fulfilled, (state, action) => {

--- a/frontend/src/features/session/thunks/timelineThunks.ts
+++ b/frontend/src/features/session/thunks/timelineThunks.ts
@@ -361,7 +361,27 @@ export const glueClipsRemote = createAsyncThunk(
 
 export const selectClipRemote = createAsyncThunk(
     "session/selectClipRemote",
-    async (clipId: string | null) => {
-        return webApi.selectClip(clipId);
+    async (
+        arg:
+            | string
+            | null
+            | {
+                  clipId: string | null;
+                  preserveTrackFocus?: boolean;
+              },
+    ) => {
+        const clipId =
+            typeof arg === "object" && arg !== null && "clipId" in arg ? arg.clipId : arg;
+        const preserveTrackFocus =
+            typeof arg === "object" && arg !== null ? Boolean(arg.preserveTrackFocus) : false;
+
+        const payload = await webApi.selectClip(clipId);
+        if (payload && typeof payload === "object") {
+            return {
+                ...payload,
+                __preserveTrackFocus: preserveTrackFocus,
+            };
+        }
+        return payload;
     },
 );

--- a/frontend/src/i18n/en-US.ts
+++ b/frontend/src/i18n/en-US.ts
@@ -332,6 +332,8 @@ export const enUS = {
     kb_project_save_as: "Save As",
     kb_project_export: "Export Audio",
     kb_track_add: "Add Track",
+    kb_track_select_up: "Select Previous Track",
+    kb_track_select_down: "Select Next Track",
     kb_clip_delete: "Delete Clip",
     kb_clip_copy: "Copy Clip",
     kb_clip_cut: "Cut Clip",

--- a/frontend/src/i18n/ja-JP.ts
+++ b/frontend/src/i18n/ja-JP.ts
@@ -338,6 +338,8 @@ export const jaJP = {
     kb_project_save_as: "名前を付けて保存",
     kb_project_export: "オーディオをエクスポート",
     kb_track_add: "トラックを追加",
+    kb_track_select_up: "ひとつ上のトラックを選択",
+    kb_track_select_down: "ひとつ下のトラックを選択",
     kb_clip_delete: "クリップを削除",
     kb_clip_copy: "クリップをコピー",
     kb_clip_cut: "クリップをカット",

--- a/frontend/src/i18n/ko-KR.ts
+++ b/frontend/src/i18n/ko-KR.ts
@@ -409,6 +409,8 @@ export const koKR = {
     kb_project_save_as: "다른 이름으로 저장",
     kb_project_export: "오디오 내보내기",
     kb_track_add: "트랙 추가",
+    kb_track_select_up: "이전 트랙 선택",
+    kb_track_select_down: "다음 트랙 선택",
     kb_clip_delete: "클립 삭제",
     kb_clip_copy: "클립 복사",
     kb_clip_cut: "클립 잘라내기",

--- a/frontend/src/i18n/zh-CN.ts
+++ b/frontend/src/i18n/zh-CN.ts
@@ -325,6 +325,8 @@ export const zhCN = {
     kb_project_save_as: "另存为",
     kb_project_export: "导出音频",
     kb_track_add: "新建轨道",
+    kb_track_select_up: "选择上一条轨道",
+    kb_track_select_down: "选择下一条轨道",
     kb_clip_delete: "删除音频块",
     kb_clip_copy: "复制音频块",
     kb_clip_cut: "剪切音频块",

--- a/frontend/src/i18n/zh-TW.ts
+++ b/frontend/src/i18n/zh-TW.ts
@@ -326,6 +326,8 @@ export const zhTW = {
     kb_project_save_as: "另存新檔",
     kb_project_export: "匯出音訊",
     kb_track_add: "新建軌道",
+    kb_track_select_up: "選取上一條軌道",
+    kb_track_select_down: "選取下一條軌道",
     kb_clip_delete: "刪除音訊片段",
     kb_clip_copy: "複製音訊片段",
     kb_clip_cut: "剪下音訊片段",


### PR DESCRIPTION
1. 为音频块适配按住 `Ctrl` 进行多选、按住 `Shift` 进行范围选择的音频块选择逻辑。
2. 修改粘贴快捷键逻辑，若用户焦点为左侧轨道头，则按下粘贴快捷键（默认是 `Ctrl + V`）后，仍然尝试进行参数编辑器的粘贴操作，而不是旧逻辑中的粘贴音频块操作。此改动是为了更方便地进行跨轨道的参数线复制粘贴操作。
3. 新增 `选择上一条轨道` `选择下一条轨道` 快捷键，默认为 `↑` `↓`。同时，将原先的 `时间轴水平放大` `时间轴水平缩小`的默认快捷键从原来的  `↑` `↓` 修改为 `无`。
4. 禁用轨道界面与参数编辑器界面按住 `↑` `↓` `←` `→` 方向键时，对界面的平移操作，并为 `播放光标左移` `播放光标右移` `时间轴水平放大` `时间轴水平缩小` `选择上一条轨道` `选择下一条轨道` 的快捷键支持长按逻辑。
5. 移除 GitHub Actions 的前端格式化检查。