### PR TITLE
fix(waveform): LRU 32→128 + 离屏双缓冲消除 clearRect 闪白

### DIFF
--- a/frontend/src/components/waveform/WaveformTrackCanvas.tsx
+++ b/frontend/src/components/waveform/WaveformTrackCanvas.tsx
@@ -98,10 +98,10 @@ export const WaveformTrackCanvas = React.memo(
         // refs：高频变化的参数存 ref，避免 React re-render
         // ========================================
         const canvasRef = React.useRef<HTMLCanvasElement | null>(null);
+        // 离屏 Canvas 双缓冲：先绘制到离屏，再 drawImage 到可见 canvas，消除 clearRect 闪白
+        const offscreenRef = React.useRef<HTMLCanvasElement | null>(null);
         const lastLevelByClipRef = React.useRef<Record<string, 0 | 1 | 2>>({});
         const rafRef = React.useRef<number | null>(null);
-        // 缓存 canvas 上次物理尺寸，避免设置 canvas.width/height 属性导致强制清空
-        const lastCanvasDimsRef = React.useRef({ w: 0, h: 0 });
 
         // 高频参数用 ref 存储，避免依赖数组变化触发 useLayoutEffect
         const pxPerSecRef = React.useRef(props.pxPerSec);
@@ -182,34 +182,34 @@ export const WaveformTrackCanvas = React.memo(
 
             // 取消限制 dpr 为 1
             const dpr = window.devicePixelRatio || 1;
-            // 用 Math.round 代替 Math.floor，消除浮点累积误差导致的帧间尺寸振荡
             const internalW = Math.max(1, Math.round(displayW * dpr));
             const internalH = Math.max(1, Math.round(displayH * dpr));
 
-            // 仅当物理尺寸真正变化时才设置 canvas.width/height（设置即清空画布）
-            const lastDims = lastCanvasDimsRef.current;
-            const dimsChanged = lastDims.w !== internalW || lastDims.h !== internalH;
-            if (dimsChanged) {
-                canvas.width = internalW;
-                canvas.height = internalH;
-                lastCanvasDimsRef.current = { w: internalW, h: internalH };
+            // 确保离屏 canvas 尺寸匹配
+            let offscreen = offscreenRef.current;
+            if (!offscreen || offscreen.width !== internalW || offscreen.height !== internalH) {
+                offscreen = document.createElement("canvas");
+                offscreen.width = internalW;
+                offscreen.height = internalH;
+                offscreenRef.current = offscreen;
             }
+            const offCtx = offscreen.getContext("2d");
+            if (!offCtx) return;
+
+            // 离屏 canvas 的坐标变换
+            const scaleX = internalW / Math.max(1, displayW);
+            const scaleY = internalH / Math.max(1, displayH);
+            offCtx.setTransform(scaleX, 0, 0, scaleY, 0, 0);
+            offCtx.clearRect(0, 0, displayW, displayH);
+
+            // 确保可见 canvas 尺寸匹配，只设一次
+            if (canvas.width !== internalW) canvas.width = internalW;
+            if (canvas.height !== internalH) canvas.height = internalH;
+            if (canvas.style.width !== `${displayW}px`) canvas.style.width = `${displayW}px`;
+            if (canvas.style.height !== `${displayH}px`) canvas.style.height = `${displayH}px`;
 
             const ctx = canvas.getContext("2d");
             if (!ctx) return;
-
-            if (dimsChanged) {
-                // 尺寸变化后重设 scale
-                const scaleX = internalW / Math.max(1, displayW);
-                const scaleY = internalH / Math.max(1, displayH);
-                ctx.setTransform(scaleX, 0, 0, scaleY, 0, 0);
-            }
-
-            ctx.clearRect(0, 0, displayW, displayH);
-
-            // CSS 尺寸也只在变化时写入，避免触发不必要的 layout
-            if (canvas.style.width !== `${displayW}px`) canvas.style.width = `${displayW}px`;
-            if (canvas.style.height !== `${displayH}px`) canvas.style.height = `${displayH}px`;
 
             if (__perfDebug) __tSetup = performance.now() - __t0;
 
@@ -399,21 +399,21 @@ export const WaveformTrackCanvas = React.memo(
                     alpha: number,
                 ) => {
                     if (segmentRightPx - segmentLeftPx <= 1e-6) return;
-                    ctx.save();
-                    ctx.beginPath();
+                    offCtx.save();
+                    offCtx.beginPath();
                     // 严格裁剪在片段实际可见范围内，防止越界绘制到其他片段上
-                    ctx.rect(segmentLeftPx, 0, segmentRightPx - segmentLeftPx, displayH);
-                    ctx.clip();
-                    ctx.globalAlpha = alpha;
+                    offCtx.rect(segmentLeftPx, 0, segmentRightPx - segmentLeftPx, displayH);
+                    offCtx.clip();
+                    offCtx.globalAlpha = alpha;
                     renderWaveform(
-                        ctx,
+                        offCtx,
                         withGains,
                         params,
                         currentStrokeColor,
                         currentStrokeWidth,
                         "line",
                     );
-                    ctx.restore();
+                    offCtx.restore();
                 };
 
                 if (leadingOverlapVisibleRight > visLeftPx + 1e-6) {
@@ -463,9 +463,13 @@ export const WaveformTrackCanvas = React.memo(
                 }
             }
 
-            if (ctx.globalAlpha !== 1) {
-                ctx.globalAlpha = 1;
+            if (offCtx.globalAlpha !== 1) {
+                offCtx.globalAlpha = 1;
             }
+
+            // 双缓冲：离屏绘制完成后，一次性 copy 到可见 canvas
+            ctx.clearRect(0, 0, displayW, displayH);
+            ctx.drawImage(offscreen, 0, 0);
 
             // ========================================
             // 性能诊断输出
@@ -565,7 +569,7 @@ export const WaveformTrackCanvas = React.memo(
                     pointerEvents: "none",
                     zIndex: 1,
                     left: 0,
-                    willChange: "transform",
+                    left: 0,
                     // 移除 left 和 width
                     // 它们属于高频变化属性，已完全交由内部 drawRef 直接操作 DOM 更新。
                 }}

--- a/frontend/src/utils/waveformMipmapStore.ts
+++ b/frontend/src/utils/waveformMipmapStore.ts
@@ -40,7 +40,7 @@ const LEVEL_COUNT = 3;
  * 每个 entry 包含三级 Float32Array，单首 5 分钟立体声歌曲约占数 MB。
  * 该上限在"避免内存累积"与"频繁切换音频不需要重新解码"之间取折中。
  */
-const MAX_FILE_CACHE_SIZE = 32;
+const MAX_FILE_CACHE_SIZE = 128;
 
 // ============== 类型 ==============
 


### PR DESCRIPTION
LRU 从 32 提高到 128，防止多文件项目触发频繁淘汰导致数据帧间缺失。渲染改用离屏 Canvas 双缓冲: 所有 clip 先绘制到离屏 offCtx，最后一次性 drawImage 到可见 canvas，消除 clearRect→fillRect 之间的可视闪白。移除 willChange:transform GPU 层。